### PR TITLE
Add env example and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ dist
 
 # Environment files (comprehensive coverage)
 
+.env
+
 *token.json*
 *credentials.json*
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ Application desktop de gestion de tournois de pétanque développée en Python a
 pip install -r requirements.txt
 ```
 
+Copiez le fichier d'exemple d'environnement puis personnalisez-le :
+```bash
+cp backend/.env.example backend/.env
+```
+
 ### Lancement de l'Application
 ```bash
 python main.py

--- a/backend/.env
+++ b/backend/.env
@@ -1,2 +1,0 @@
-MONGO_URL="mongodb://localhost:27017"
-DB_NAME="test_database"

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+MONGO_URL="mongodb://YOUR_DB_HOST:PORT"
+DB_NAME="your_database"


### PR DESCRIPTION
## Summary
- switch backend `.env` to `.env.example`
- ignore `.env` in git
- document copying `.env.example` in README

## Testing
- `pytest -q` *(fails: fixture 'tournament_id' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68564a2a93c8832482dcf93fbb5bd544