### PR TITLE
Implement tournament deletion

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -161,11 +161,14 @@ class MainWindow:
         
         tournament = db_manager.get_tournament(self.current_tournament_id)
         if tournament:
-            response = messagebox.askyesno("Confirmation", 
+            response = messagebox.askyesno("Confirmation",
                                          f"Êtes-vous sûr de vouloir supprimer le tournoi '{tournament['name']}'?")
             if response:
-                # TODO: Implémenter la suppression
-                messagebox.showinfo("Info", "Fonctionnalité de suppression à implémenter")
+                db_manager.delete_tournament(self.current_tournament_id)
+                self.load_tournaments()
+                self.tournament_combo.set('')
+                self.current_tournament_id = None
+                self.refresh_all_widgets()
     
     def on_tournament_change(self, event=None):
         """Appelé quand le tournoi sélectionné change"""

--- a/store.py
+++ b/store.py
@@ -123,6 +123,15 @@ class DatabaseManager:
                 WHERE id = ?
             ''', values)
             conn.commit()
+
+    def delete_tournament(self, tournament_id: str):
+        """Supprime un tournoi et toutes les donn\xC3\xA9es associ\xC3\xA9es"""
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute('DELETE FROM matches WHERE tournament_id = ?', (tournament_id,))
+            cursor.execute('DELETE FROM teams WHERE tournament_id = ?', (tournament_id,))
+            cursor.execute('DELETE FROM tournaments WHERE id = ?', (tournament_id,))
+            conn.commit()
     
     # CRUD pour Équipes
     def create_team(self, tournament_id: str, name: str, players: List[str]) -> str:


### PR DESCRIPTION
## Summary
- support deleting tournaments in the store layer
- wire up tournament deletion from the GUI

## Testing
- `pytest -q` *(fails: fixture 'tournament_id' not found)*
- `python test_console.py`

------
https://chatgpt.com/codex/tasks/task_e_68564da5666c8324b92b88be79000edb