### PR TITLE
Add database deletion helpers and integrate with UI

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -135,11 +135,14 @@ class MainWindow:
         tournaments = db_manager.get_all_tournaments()
         tournament_names = [f"{t['name']} ({t['type']})" for t in tournaments]
         self.tournament_combo['values'] = tournament_names
-        
+
         if tournaments:
             self.tournament_combo.current(0)
             self.current_tournament_id = tournaments[0]['id']
             self.on_tournament_change()
+        else:
+            self.current_tournament_id = None
+            self.tournament_combo.set('')
     
     def create_tournament(self):
         """Ouvre la boîte de dialogue pour créer un tournoi"""
@@ -161,11 +164,18 @@ class MainWindow:
         
         tournament = db_manager.get_tournament(self.current_tournament_id)
         if tournament:
-            response = messagebox.askyesno("Confirmation", 
+            response = messagebox.askyesno("Confirmation",
                                          f"Êtes-vous sûr de vouloir supprimer le tournoi '{tournament['name']}'?")
             if response:
-                # TODO: Implémenter la suppression
-                messagebox.showinfo("Info", "Fonctionnalité de suppression à implémenter")
+                try:
+                    db_manager.delete_tournament(self.current_tournament_id)
+                    self.current_tournament_id = None
+                    self.load_tournaments()
+                    self.refresh_all_widgets()
+                    self.update_status(f"Tournoi '{tournament['name']}' supprimé")
+                except Exception as e:
+                    messagebox.showerror("Erreur",
+                                         f"Erreur lors de la suppression: {str(e)}")
     
     def on_tournament_change(self, event=None):
         """Appelé quand le tournoi sélectionné change"""

--- a/widgets/team_widget.py
+++ b/widgets/team_widget.py
@@ -170,11 +170,23 @@ class TeamWidget:
         if not selection:
             messagebox.showwarning("Attention", "Aucune équipe sélectionnée")
             return
-        
+
         team_id = selection[0]
-        # TODO: Implémenter la suppression d'équipe
-        messagebox.showinfo("Info", "Fonctionnalité de suppression à implémenter")
-    
+        team_name = self.teams_tree.item(team_id, 'values')[0]
+        response = messagebox.askyesno(
+            "Confirmation",
+            f"Supprimer l'équipe '{team_name}' et ses matchs ?"
+        )
+        if response:
+            try:
+                db_manager.delete_team(team_id)
+                self.main_window.refresh_all_widgets()
+                self.main_window.update_status(
+                    f"Équipe '{team_name}' supprimée")
+            except Exception as e:
+                messagebox.showerror("Erreur",
+                                     f"Erreur lors de la suppression: {str(e)}")
+
     def edit_team(self):
         """Modifie l'équipe sélectionnée"""
         selection = self.teams_tree.selection()


### PR DESCRIPTION
## Summary
- add delete helpers for tournaments, teams and matches
- wire up team & tournament delete buttons to use new helpers
- refresh tournament list when no tournaments remain

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: fixture 'tournament_id' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68564dabea648324bd704b6acd6249ae