### PR TITLE
Implement court change functionality

### DIFF
--- a/store.py
+++ b/store.py
@@ -217,10 +217,21 @@ class DatabaseManager:
         with self.get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute('''
-                UPDATE matches 
+                UPDATE matches
                 SET team1_score = ?, team2_score = ?, status = 'finished'
                 WHERE id = ?
             ''', (team1_score, team2_score, match_id))
+            conn.commit()
+
+    def update_match_court(self, match_id: str, court_number: int):
+        """Met à jour le numéro de terrain d'un match"""
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute('''
+                UPDATE matches
+                SET court_number = ?
+                WHERE id = ?
+            ''', (court_number, match_id))
             conn.commit()
     
     def get_team_standings(self, tournament_id: str) -> List[Dict]:

--- a/widgets/match_widget.py
+++ b/widgets/match_widget.py
@@ -4,7 +4,7 @@ Affiche les matchs et permet la saisie des scores
 """
 
 import tkinter as tk
-from tkinter import ttk, messagebox
+from tkinter import ttk, messagebox, simpledialog
 from store import db_manager
 from tournament import TournamentManager
 
@@ -216,10 +216,26 @@ class MatchWidget:
         if not selection:
             messagebox.showwarning("Attention", "Aucun match sélectionné")
             return
-        
+
         match_id = selection[0]
-        # TODO: Implémenter le changement de terrain
-        messagebox.showinfo("Info", "Fonctionnalité de changement de terrain à implémenter")
+        try:
+            current_values = self.matches_tree.item(match_id, 'values')
+            initial_court = current_values[0] if current_values else ''
+            new_court = simpledialog.askinteger(
+                "Changer le terrain",
+                "Nouveau numéro de terrain:",
+                initialvalue=initial_court,
+                parent=self.parent,
+                minvalue=1
+            )
+            if new_court is None:
+                return
+
+            db_manager.update_match_court(match_id, new_court)
+            self.refresh()
+            self.main_window.update_status(f"Terrain mis à jour: {new_court}")
+        except Exception as e:
+            messagebox.showerror("Erreur", f"Erreur lors de la mise à jour du terrain: {str(e)}")
     
     def refresh(self):
         """Rafraîchit l'affichage des matchs"""


### PR DESCRIPTION
## Summary
- allow updating match court in the database
- prompt for new court from the match widget
- refresh matches after updating court

## Testing
- `pytest -q` *(fails: fixture 'tournament_id' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68564daec1d48324b0c27928cf5f19d5