### PR TITLE
Fix PyInstaller hidden imports

### DIFF
--- a/build_exe.py
+++ b/build_exe.py
@@ -51,6 +51,9 @@ def create_exe():
     # Ajouter les données nécessaires
     cmd.extend([
         "--add-data", "resources;resources",  # Inclure le dossier resources
+        "--hidden-import=reportlab.lib",
+        "--hidden-import=reportlab.platypus",
+        "--hidden-import=reportlab.pdfgen",
     ])
     
     try:


### PR DESCRIPTION
## Summary
- ensure reportlab modules are bundled by PyInstaller

## Testing
- `python -m PyInstaller --clean --onefile --windowed --name=main --distpath=dist --workpath=build --specpath=. main.py --add-data=resources:resources --hidden-import=reportlab.lib --hidden-import=reportlab.platypus --hidden-import=reportlab.pdfgen --icon resources/logo.ico`


------
https://chatgpt.com/codex/tasks/task_e_68566a381e788324980c9a562cb7be05